### PR TITLE
feat: add Squid to dapps list

### DIFF
--- a/dapp/dapps.json
+++ b/dapp/dapps.json
@@ -333,5 +333,257 @@
             "medium": "https://medium.com/@tfm.com",
             "discord": "https://discord.gg/tfm_agg"
         }          
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "cosmos",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "osmosis",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "assetmantle",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "binance",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "comdex",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "crescent",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "evmos",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "fetch.ai",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "juno",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "kava",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "kichain",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "kujira",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "omniflix",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "regen",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "secret",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "stargaze",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "umee",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
+    },
+    {
+        "title": "Squid",
+        "description": "Swap any token between chains.",
+        "logo": "https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png",
+        "url": "https://app.squidrouter.com",
+        "chain": "bnb",
+        "badge": "Defi",
+        "links": {
+        "webSite": "https://squidrouter.com",
+        "github": "https://github.com/0xsquid",
+        "twitter": "https://twitter.com/squidrouter",
+        "medium": "https://medium.com/@squidrouter"
+        }
     }
 ]


### PR DESCRIPTION
Adds Squid linked to these chains

- cosmos
- osmosis
- assetmantle
- binance
- comdex
- crescent
- evmos
- fetch.ai
- juno
- kava
- kichain
- kujira
- omniflix
- regen
- secret
- stargaze
- umee

No logo provided on https://raw.githubusercontent.com/cosmostation/chainlist/master/dapp/image/squid.png