### PR TITLE
Add NEOK token for Crescent network

### DIFF
--- a/chain/crescent/assets.json
+++ b/chain/crescent/assets.json
@@ -589,5 +589,25 @@
     },
     "image": "crypto-org/asset/cro.png",
     "coinGeckoId": "crypto-com-chain"
+  },
+  {
+    "denom": "ibc/4DD3698C2FCEA87CDE843D3EA6228F2589A4DF6655A7C16D766010D9CA2E69FB",
+    "type": "ibc",
+    "origin_chain": "evmos",
+    "origin_denom": "neok",
+    "origin_type": "erc20",
+    "symbol": "NEOK",
+    "decimals": 18,
+    "enable": true,
+    "path": "evmos>crescent",
+    "channel": "channel-7",
+    "port": "transfer",
+    "counter_party": {
+      "channel": "channel-11",
+      "port": "transfer",
+      "denom": "erc20/0x655ecB57432CC1370f65e5dc2309588b71b473A9"
+    },
+    "image": "evmos/asset/neok.png",
+    "coinGeckoId": ""
   }
 ]


### PR DESCRIPTION
This PR is to add our NEOK token metadata to Crescent.

Today we moved few NEOKs from EVMOS to Crescent, see: https://www.mintscan.io/crescent/txs/BBAE4CCF54DD36E4AC43486482ADF4C80FD606F376512778013B20228A3F2465?height=6726194

The denom of our token in Crescent is `sha256(transfer/channel-7/erc20/0x655ecB57432CC1370f65e5dc2309588b71b473A9)`

Where:

- `transfer` is the port
- `channel-7` is the channel between Crescent and EVMOS
- `erc20/...` is the address of our token

Our NEOK token is an ERC20 that has been registered as an IBC coin in an [EVMOS Govrnance proposal](https://app.evmos.org/governance?id=144). I made already two PRs to this repo:

- #538 
- #541

I'm not fully sure about the metadata, especially `counter_party.denom`. How to verify it? Also, do I need to do a PR to this repo for each network my token can be transferred to?