### PR TITLE
Add NEOK denom for crescent>evmos IBC

### DIFF
--- a/chain/evmos/assets.json
+++ b/chain/evmos/assets.json
@@ -391,5 +391,25 @@
     "enable": true,
     "image": "evmos/asset/neok.png",
     "contract": "0x655ecB57432CC1370f65e5dc2309588b71b473A9"
+  },
+  {
+    "denom": "ibc/4DD3698C2FCEA87CDE843D3EA6228F2589A4DF6655A7C16D766010D9CA2E69FB",
+    "type": "ibc",
+    "origin_chain": "crescent",
+    "origin_denom": "neok",
+    "origin_type": "ibc",
+    "symbol": "NEOK",
+    "decimals": 18,
+    "enable": true,
+    "path": "crescent>evmos",
+    "channel": "channel-11",
+    "port": "transfer",
+    "counter_party": {
+      "channel": "channel-7",
+      "port": "transfer",
+      "denom": "neok"
+    },
+    "image": "evmos/asset/neok.png",
+    "contract": "0x655ecB57432CC1370f65e5dc2309588b71b473A9"
   }
 ]


### PR DESCRIPTION
I already made these other PRs:

- #538
- #541
- #599

Today we:

- Made an IBC transfer of some NEOK coin from EVMOS to Crescent
- Made a transfer in Crescent from one account to another ([see tx](https://www.mintscan.io/crescent/txs/9C84FC67B9B1E99FDA8625ADCB664F24B651AEB3A979783DDFD53A30640C26E6?height=6748081))
- Made an IBC transfer of one NEOK coin from Crescent to EVMOS ([see tx](https://www.mintscan.io/evmos/txs/2AF50D0BA7925878F24FD26D9ADE29B22A267D7AD27D5BC5A15ED296F55F89F7?height=13616425))

The last transfer doesn't show up in the [asset balance of the receiver](https://www.mintscan.io/evmos/account/evmos1m5gusj2k5nyyafd48umx9uxwl327twczn6ge6h). I was wondering that maybe there is some data missing in this registry, and I made this PR. Please note that I'm not fully sure about some of values I put in the json, so please review it carefully.