### PR TITLE
Add Stride assets to Cosmos Hub

### DIFF
--- a/chain/cosmos/assets.json
+++ b/chain/cosmos/assets.json
@@ -757,7 +757,7 @@
     "origin_chain": "stride",
     "origin_denom": "ustrd",
     "origin_type": "staking",
-    "symbol": "stATOM",
+    "symbol": "STRD",
     "decimals": 6,
     "enable": true,
     "path": "stride>cosmos",

--- a/chain/cosmos/assets.json
+++ b/chain/cosmos/assets.json
@@ -750,5 +750,43 @@
     },
     "image": "neutron/asset/ntrn.png",
     "coinGeckoId": "neutron-3"
+  },
+  {
+    "denom": "ibc/6B8A3F5C2AD51CD6171FA41A7E8C35AD594AB69226438DB94450436EA57B3A89",
+    "type": "ibc",
+    "origin_chain": "stride",
+    "origin_denom": "ustrd",
+    "origin_type": "staking",
+    "symbol": "stATOM",
+    "decimals": 6,
+    "enable": true,
+    "path": "stride>cosmos",
+    "channel": "channel-391",
+    "port": "transfer",
+    "counter_party": {
+      "channel": "channel-0",
+      "port": "transfer",
+      "denom": "stustrd"
+    },
+    "image": "stride/asset/strd.png"
+  },
+  {
+    "denom": "ibc/B05539B66B72E2739B986B86391E5D08F12B8D5D2C2A7F8F8CF9ADF674DFA231",
+    "type": "ibc",
+    "origin_chain": "stride",
+    "origin_denom": "stuatom",
+    "origin_type": "native",
+    "symbol": "stATOM",
+    "decimals": 6,
+    "enable": true,
+    "path": "stride>cosmos",
+    "channel": "channel-391",
+    "port": "transfer",
+    "counter_party": {
+      "channel": "channel-0",
+      "port": "transfer",
+      "denom": "stuatom"
+    },
+    "image": "stride/asset/statom.png"
   }
 ]


### PR DESCRIPTION
This PR adds Stride's stATOM and STRD tokens to display when bridged to the Cosmos Hub. 

The denom trace for STRD can be verified [here](https://lcd-cosmoshub.blockapsis.com/ibc/apps/transfer/v1/denom_traces/6B8A3F5C2AD51CD6171FA41A7E8C35AD594AB69226438DB94450436EA57B3A89), and the denom trace for stATOM can be verified [here](https://lcd-cosmoshub.blockapsis.com/ibc/apps/transfer/v1/denom_traces/B05539B66B72E2739B986B86391E5D08F12B8D5D2C2A7F8F8CF9ADF674DFA231).

Please let me know if anything should be changed, or if there's anything I can help clarify!