### PR TITLE
Integrate NEOK denom for evmos<>injective

### DIFF
--- a/chain/evmos/assets.json
+++ b/chain/evmos/assets.json
@@ -391,5 +391,25 @@
     "enable": true,
     "image": "evmos/asset/neok.png",
     "contract": "0x655ecB57432CC1370f65e5dc2309588b71b473A9"
+  },
+  {
+    "denom": "ibc/6940f7f14c91399febb10170381244ce17040f1418ed4e5e9c7a17ee9ed7a043",
+    "type": "ibc",
+    "origin_chain": "injective",
+    "origin_denom": "neok",
+    "origin_type": "ibc",
+    "symbol": "NEOK",
+    "decimals": 18,
+    "enable": true,
+    "path": "injective>evmos",
+    "channel": "channel-83",
+    "port": "transfer",
+    "counter_party": {
+      "channel": "channel-10",
+      "port": "transfer",
+      "denom": "neok"
+    },
+    "image": "evmos/asset/neok.png",
+    "contract": "0x655ecB57432CC1370f65e5dc2309588b71b473A9"
   }
 ]

--- a/chain/injective/assets.json
+++ b/chain/injective/assets.json
@@ -827,5 +827,25 @@
     "image": "ethereum/asset/lym.png",
     "coinGeckoId": "lympo",
     "contract": "0xc690F7C7FcfFA6a82b79faB7508c466FEfdfc8c5"
+  },
+  {
+    "denom": "ibc/6940f7f14c91399febb10170381244ce17040f1418ed4e5e9c7a17ee9ed7a043",
+    "type": "ibc",
+    "origin_chain": "evmos",
+    "origin_denom": "neok",
+    "origin_type": "erc20",
+    "symbol": "NEOK",
+    "decimals": 18,
+    "enable": true,
+    "path": "evmos>injective",
+    "channel": "channel-10",
+    "port": "transfer",
+    "counter_party": {
+      "channel": "channel-83",
+      "port": "transfer",
+      "denom": "erc20/0x655ecB57432CC1370f65e5dc2309588b71b473A9"
+    },
+    "image": "evmos/asset/neok.png",
+    "coinGeckoId": ""
   }
 ]


### PR DESCRIPTION
Today we have transferred one NEOK token from EVMOS to Injective

https://www.mintscan.io/injective/txs/851F96EDED9ABBA00EE9C67C8A0DE15ED074546CAA1B21567E86CDFD403EE7C8?height=39066934

As the token does not show up as an asset on mintscan, we are adding the metadata to handle it in this pull request.
The PR contains:
- asset metadata for NEOK tokens going from evmos to injective
- asset metadata for NEOK tokens going from injective to evmos