### PR TITLE
add supported squid chains

### DIFF
--- a/chain/swap.json
+++ b/chain/swap.json
@@ -88,6 +88,12 @@
         },
         {
           "chainId": "umee-1"
+        },
+        {
+          "chainId": "neutron-1"
+        },
+        {
+          "chainId": "dimension_37-1"
         }
       ]
     },
@@ -113,6 +119,9 @@
         },
         {
           "chainId": "2222"
+        },
+        {
+          "chainId": "10"
         }
       ],
       "receive": [
@@ -136,6 +145,9 @@
         },
         {
           "chainId": "2222"
+        },
+        {
+          "chainId": "10"
         }
       ]
     }


### PR DESCRIPTION
The list of supported chains has been changed as the supported chains have changed in Squid Swap.