### PR TITLE
Integrate NEOK denom for evmos>osmosis

### DIFF
--- a/chain/osmosis/assets.json
+++ b/chain/osmosis/assets.json
@@ -524,7 +524,7 @@
     "coinGeckoId": "evmos"
   },
   {
-    "denom": "ibc/dee262653b9de39bcef0493d47e0dfc4fe62f7f046cf38b9fdefebe98d149a71",
+    "denom": "ibc/DEE262653B9DE39BCEF0493D47E0DFC4FE62F7F046CF38B9FDEFEBE98D149A71",
     "type": "ibc",
     "origin_chain": "evmos",
     "origin_denom": "neok",

--- a/chain/osmosis/assets.json
+++ b/chain/osmosis/assets.json
@@ -524,6 +524,26 @@
     "coinGeckoId": "evmos"
   },
   {
+    "denom": "ibc/dee262653b9de39bcef0493d47e0dfc4fe62f7f046cf38b9fdefebe98d149a71",
+    "type": "ibc",
+    "origin_chain": "evmos",
+    "origin_denom": "neok",
+    "origin_type": "erc20",
+    "symbol": "NEOK",
+    "decimals": 18,
+    "enable": true,
+    "path": "evmos>osmosis",
+    "channel": "channel-204",
+    "port": "transfer",
+    "counter_party": {
+      "channel": "channel-0",
+      "port": "transfer",
+      "denom": "erc20/0x655ecB57432CC1370f65e5dc2309588b71b473A9"
+    },
+    "image": "evmos/asset/neok.png",
+    "coinGeckoId": ""
+  },
+  {
     "denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
     "type": "ibc",
     "origin_chain": "cerberus",


### PR DESCRIPTION
Today we have transferred one NEOK token from EVMOS to Osmosis.

https://www.mintscan.io/osmosis/transactions/14560235DAB1AEA3A25BC1165DDE7AF742C6577CBF82B2D07688029EA3646F98

As the token does not show up as an asset on mintscan, we are adding the metadata to handle it.
The PR contains the asset metadata for NEOK tokens going from Evmos to Osmosis.