### PR TITLE
Add NEOK denom for Evmos > Injective

### DIFF
--- a/chain/injective/assets.json
+++ b/chain/injective/assets.json
@@ -847,5 +847,25 @@
     "image": "ethereum/asset/lym.png",
     "coinGeckoId": "lympo",
     "contract": "0xc690F7C7FcfFA6a82b79faB7508c466FEfdfc8c5"
+  },
+  {
+    "denom": "ibc/F6CC233E5C0EA36B1F74AB1AF98471A2D6A80E2542856639703E908B4D93E7C4",
+    "type": "ibc",
+    "origin_chain": "evmos",
+    "origin_denom": "neok",
+    "origin_type": "erc20",
+    "symbol": "NEOK",
+    "decimals": 18,
+    "enable": true,
+    "path": "evmos>injective",
+    "channel": "channel-83",
+    "port": "transfer",
+    "counter_party": {
+      "channel": "channel-10",
+      "port": "transfer",
+      "denom": "erc20/0x655ecB57432CC1370f65e5dc2309588b71b473A9"
+    },
+    "image": "evmos/asset/neok.png",
+    "coinGeckoId": ""
   }
 ]


### PR DESCRIPTION
Denom was calculated with `sha256(transfer/channel-83/erc20/0x655ecB57432CC1370f65e5dc2309588b71b473A9)`

This is the relayer between Evmos and Injective: https://dev.mintscan.io/evmos/relayers/channel-10/injective/channel-83