### PR TITLE
Readme: Update token list uses wrong folder path

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@
 ---
 
 - Native Token
-  `/assets/v2/${chain}/assets.json`
+  `chain/${chain}/assets.json`
 
   ```json
   // example OSMOSIS


### PR DESCRIPTION
Folder path in `How to add your token info` doesn't exist. Now points to folder that does exist.