### PR TITLE
Fix invalid JSON formatting in planq assets.json

### DIFF
--- a/chain/planq/assets.json
+++ b/chain/planq/assets.json
@@ -30,5 +30,5 @@
     },
     "image": "osmosis/asset/osmo.png",
     "coinGeckoId": "osmosis"
-  },
+  }
 ]


### PR DESCRIPTION
The planq assets.json has an extra comma which is invalid JSON, so this causes issues with JSON parsers.