### PR TITLE
Update SudoStake Dapp Info

### DIFF
--- a/wallet_mobile/dapp/dapps.json
+++ b/wallet_mobile/dapp/dapps.json
@@ -198,7 +198,7 @@
       "url": "https://www.sudostake.com",
       "chain": ["archway"],
       "category": "Defi",
-      "tag":["Staking"]
+      "tag":["Staking", "Dex"]
   },
   {
     "title": "Ninja Blaze",

--- a/wallet_mobile/dapp/dapps.json
+++ b/wallet_mobile/dapp/dapps.json
@@ -195,10 +195,10 @@
       "title": "Sudo Stake",
       "description": "On-chain property rights for everyone.",
       "logo": "https://raw.githubusercontent.com/sudostake/sudostake_web/main/public/logo_light.png",
-      "URL": "https://www.sudostake.com",
+      "url": "https://www.sudostake.com",
       "chain": ["archway"],
       "category": "Defi",
-      "tag":["Dex", "Staking"]
+      "tag":["Staking"]
   },
   {
     "title": "Ninja Blaze",


### PR DESCRIPTION
This PR introduces 2 changes
1. Change URL to url, because launching the Dapp returns undefined.
2. Staking should be the default tag.