### PR TITLE
chore: fix 404 status URL

### DIFF
--- a/chain/cnho_stables/param_2.json
+++ b/chain/cnho_stables/param_2.json
@@ -41,7 +41,7 @@
     ],
     "about" : {
         "website" : "https://cnho.io/",
-        "github" : "https://github.com/alashooinc/Chain_CNHO",
+        "github" : "https://github.com/alashooinc/ChainCNHO",
         "coingecko" : ""
     },
     "description" : {


### PR DESCRIPTION
The previous link has expired and has been replaced with the latest address.