### PR TITLE
Fix typos

### DIFF
--- a/chain/planq/assets_2.json
+++ b/chain/planq/assets_2.json
@@ -37,7 +37,7 @@
         "denom": "ibc/26B4B4BBF3C8D5DB1ADE993CCD865A7CC608B2BAEF20E0166F18B84E32184F63",
         "name" : "nRide Token",
         "symbol": "NRIDE",
-        "description": "nRide is developing a uber-like ride-hailing protocol, leveraging cosmwasm smart-contracts for payment, driver registration and text-messaging between the rider and the driver, to create a trustless public transportation environment for any cab or taxi company to use.",
+        "description": "nRide is developing an uber-like ride-hailing protocol, leveraging cosmwasm smart-contracts for payment, driver registration and text-messaging between the rider and the driver, to create a trustless public transportation environment for any cab or taxi company to use.",
         "decimals": 6,
         "image": "https://raw.githubusercontent.com/cosmostation/chainlist/master/chain/juno/asset/nride.png",
         "coinGeckoId": "",

--- a/chain/quicksilver/param_2.json
+++ b/chain/quicksilver/param_2.json
@@ -100,7 +100,7 @@
     },
     "description" : {
         "ko" : "Cosmos Interchain 생태계 체인들을 위한 리퀴드 스테이킹 프로토콜.",
-        "en" : "Quicksilver Protocol is an liquid staking protocol for the Cosmos Interchain ecosystem.",
+        "en" : "Quicksilver Protocol is a liquid staking protocol for the Cosmos Interchain ecosystem.",
         "ja" : "Cosmos Interchainエコシステムチェーンのためのリキッドステーキング プロトコル。"
     }
 }


### PR DESCRIPTION
This pull request fixes typos in two JSON files:  
- In `assets_2.json`, changed "a uber-like" to "an uber-like" for correct article usage.  
- In `param_2.json`, changed "an liquid" to "a liquid" for correct article usage.  

These changes ensure proper grammar and consistency in the descriptions.
