### PR TITLE
Update eco_list.json for Althea

### DIFF
--- a/mintscan/chains/althea/eco_list.json
+++ b/mintscan/chains/althea/eco_list.json
@@ -1,6 +1,6 @@
 [
 	{
-	    "name": "https://althea.link/",
+	    "name": "Althea.Link",
 	    "type": "Dashboard",
 	    "description": "Staking & Governance for Althea L1",
 	    "status": "open",


### PR DESCRIPTION
change "name" to "Althea.Link" (instead of URL).

When the URL is in the title field, it gets auto-capitalized which makes it look a bit funny (like "Https://althea.link" ).