### PR TITLE
feat: add LBTC to bbn

### DIFF
--- a/chain/babylon/cw20_2.json
+++ b/chain/babylon/cw20_2.json
@@ -71,5 +71,15 @@
          "decimals": 8,
          "image": "https://raw.githubusercontent.com/cosmostation/chainlist/master/chain/babylon/asset/uniBTC.png",
          "coinGeckoId": "universal-btc"
-     }
+     },
+     {
+        "type": "cw20",
+        "contract": "bbn1z5gne4pe84tqerdrjta5sp966m98zgg5czqe4xu2yzxqfqv5tfkqed0jyy",
+        "name": "Lombard Staked Bitcoin",
+        "symbol": "LBTC.union",
+        "description": "Union bridged LBTC, staked version of Bitcoin from Lombard protocol",
+        "decimals": 8,
+        "image": "https://raw.githubusercontent.com/cosmostation/chainlist/master/chain/babylon/asset/LBTC.png",
+        "coinGeckoId": "lombard-staked-btc"
+    }
 ]


### PR DESCRIPTION
I noticed that the .union suffix and the "Union bridged" label were removed from other tokens previously.
However, since LBTC was the one that caused the confusion and PR revert, I’ve added them back here just to be safe.
If you'd prefer to remove them for consistency, just let me know and I’ll update the PR accordingly! 