### PR TITLE
feat(bbn): add satSolvBTC.e

### DIFF
--- a/chain/babylon/cw20_2.json
+++ b/chain/babylon/cw20_2.json
@@ -91,5 +91,15 @@
         "decimals": 8,
         "image": "https://raw.githubusercontent.com/cosmostation/chainlist/master/chain/babylon/asset/uniBTC.png",
         "coinGeckoId": ""
+    },
+    {
+        "type": "cw20",
+        "contract": "bbn1rl75n93kk075clrt72hqa7md6mwl78u28sghs380xuvlmksw6x3q07n2tc",
+        "name": "SatLayer xSatSolvBTC Bridged",
+        "symbol": "satSolvBTC.e",
+        "description": "Staked version of xSolvBTC from SatLayer",
+        "decimals": 18,
+        "image": "https://raw.githubusercontent.com/cosmostation/chainlist/master/chain/babylon/asset/SolvBTC.png",
+        "coinGeckoId": ""
     }
 ]


### PR DESCRIPTION
Adds new token for Union bridged asset to Babylon. The PR consists of a new cw20 for the supported asset