### PR TITLE
Replace inactive Cosmostation EVM RPC with NodeStake JSON-RPC endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,8 +462,8 @@ You must add an endpoint to `https://github.com/cosmostation/chainlist/blob/main
     ],
     "evm_rpc_endpoint" : [
         {
-            "provider": "Cosmostation",
-            "url": "https://rpc-humans-evm.cosmostation.io"
+            "provider": "NodeStake",
+            "url": "https://jsonrpc.humans.nodestake.top"
         },
         {
             "provider": "Posthuman",


### PR DESCRIPTION
Updates `chain/<chain>/param_2.json` to swap the EVM RPC entry  
