### PR TITLE
Fix incorrect URL for Etherfi project

### DIFF
--- a/wallet/eco_list.json
+++ b/wallet/eco_list.json
@@ -22,7 +22,7 @@
         "name": "Etherfi",
         "description": "EtherFi is a liquid restaking on Ethereum. Stake ETH to get eETH to reward you more across DeFi.",
         "thumbnail" : "https://raw.githubusercontent.com/cosmostation/chainlist/master/wallet/resource/etherfi.png",
-        "link": "https://app.eigenlayer.xyz",
+        "link": "https://app.ether.fi",
         "chains": [
             "ethereum",
             "arbitrum",


### PR DESCRIPTION
Changed the Etherfi project link from "https://app.eigenlayer.xyz" (Eigenlayer website) to the correct "https://app.ether.fi" (Etherfi website) to ensure users are directed to the proper platform. This matches the URL used in the mobile version of the application