### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/evm_okx.yml
+++ b/.github/workflows/evm_okx.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/evm_squid.yml
+++ b/.github/workflows/evm_squid.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/json_validate.yml
+++ b/.github/workflows/json_validate.yml
@@ -22,7 +22,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Set up Node.js
       uses: actions/setup-node@v4


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0