### PR TITLE
Add 'is_feemarket' property to mantra-testnet param_2.json

### DIFF
--- a/chain/mantra-testnet/param_2.json
+++ b/chain/mantra-testnet/param_2.json
@@ -43,7 +43,7 @@
         "fee_threshold" : ""
     },
     "evm_fee_info" : {
-        "is_eip1559": false,
+        "is_eip1559": true,
         "simulated_gas_multiply" : 1.2
     },
     "grpc_endpoint" : [


### PR DESCRIPTION
This PR is related: https://github.com/cosmostation/cosmostation-chrome-extension/pull/513