### PR TITLE
cosmoshub: add Nether (NTHR) tokenfactory asset

### DIFF
--- a/chain/cosmos/assets_2.json
+++ b/chain/cosmos/assets_2.json
@@ -1709,6 +1709,16 @@
         "coinGeckoId": ""
     },
     {
+        "type": "native",
+        "denom": "factory/cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m/Nether",
+        "name": "Nether",
+        "symbol": "NTHR",
+        "description": "Utility token of the Underworld NFT ecosystem on Cosmos Hub. Soft-staking rewards via NecroVault. Fixed supply: 21,000.",
+        "decimals": 6,
+        "image": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/nthr.png",
+        "coinGeckoId": ""
+    },
+    {
         "type": "ibc",
         "denom": "ibc/5512EB544A275E5375CE4D82233BDAA2D03002E352A9C6B0049175BD368DF10E",
         "name": "EURC",


### PR DESCRIPTION
Adds Nether (NTHR), a tokenfactory token issued on Cosmos Hub, to `chain/cosmos/assets_2.json`.

## Asset details
- **Symbol:** NTHR
- **Name:** Nether
- **Denom:** `factory/cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m/Nether`
- **Decimals:** 6
- **Type:** tokenfactory (native)
- **Issuer:** `cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m`
- **Fixed supply:** 21,000
- **Image:** reuses the asset PNG already accepted into [cosmos/chain-registry](https://github.com/cosmos/chain-registry) at `cosmoshub/images/nthr.png`

## Context
NTHR is the utility token of the Underworld NFT ecosystem on Cosmos Hub, powering soft-staking via the NecroVault platform. Holders of Underworld NFT collections earn rewards while keeping their NFTs liquid in their wallets.

- Website: https://www.necrovault.com/
- X: https://x.com/Underworld_NFTs

A parallel metadata-enrichment PR is open against `cosmos/chain-registry` ([#7686](https://github.com/cosmos/chain-registry/pull/7686)) — this PR is the Cosmostation-side asset addition so Mintscan picks it up.

## Validation
- JSON validates (`json.load` parses without error)
- Insertion follows existing tokenfactory-asset pattern (modeled after FOMOG entry directly above)
- No changes to other assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)