### PR TITLE
Update STARS description on Cosmos Hub

### DIFF
--- a/chain/cosmos/assets_2.json
+++ b/chain/cosmos/assets_2.json
@@ -1792,7 +1792,7 @@
         "denom": "factory/cosmos1s8qx0zvz8yd6e4x0mqmqf7fr9vvfn6226hkvrq/ustars",
         "name": "Stargaze",
         "symbol": "STARS",
-        "description": "The native STARS token, migrated from Stargaze to the Cosmos Hub.",
+        "description": "The native token of Stargaze",
         "decimals": 6,
         "image": "https://raw.githubusercontent.com/cosmostation/chainlist/master/chain/cosmos/asset/stars.png",
         "coinGeckoId": "stargaze"


### PR DESCRIPTION
Updating the STARS description os Cosmos Hub as the current description gets truncated. 


<img width="1634" height="936" alt="image" src="https://github.com/user-attachments/assets/94709b46-cc16-48a2-bf1d-7f27cfffb1a7" />
