### PR TITLE
Update legacy STARS symbol on Osmosis

### DIFF
--- a/chain/osmosis/assets_2.json
+++ b/chain/osmosis/assets_2.json
@@ -472,7 +472,7 @@
         "type": "ibc",
         "denom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
         "name": "Stargaze",
-        "symbol": "STARS.og",
+        "symbol": "STARS.legacy",
         "description": "The native token of Stargaze",
         "decimals": 6,
         "image": "https://raw.githubusercontent.com/cosmostation/chainlist/master/chain/stargaze/asset/stars.png",


### PR DESCRIPTION
Updates the symbol for legacy STARS on Osmosis.

Old: `STARS.og`
New: `STARS.legacy`